### PR TITLE
feat(queue): support partitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tmp
 logs
 .DS_Store
 test-results.xml
+*.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/helix-task-support",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/table/TableService.js
+++ b/test/table/TableService.js
@@ -93,14 +93,22 @@ class TableService {
     let entries = data;
     if (query._where.length) {
       query._where.forEach((clause) => {
-        let m = clause.match(/status eq '(.*)'/);
-        if (m && m[1]) {
-          entries = entries.filter((e) => e.status._ === m[1]);
+        let m = clause.match(/( and )?PartitionKey eq '(.*)'/);
+        if (m && m[2]) {
+          entries = entries.filter((e) => e.PartitionKey._ === m[2]);
+          return;
         }
-        m = clause.match(/Timestamp lt datetime'(.*)'/);
-        if (m && m[1]) {
-          entries = entries.filter((e) => e.Timestamp._ < Date.parse(m[1]));
+        m = clause.match(/( and )?status eq '(.*)'/);
+        if (m && m[2]) {
+          entries = entries.filter((e) => e.status._ === m[2]);
+          return;
         }
+        m = clause.match(/( and )?Timestamp lt datetime'(.*)'/);
+        if (m && m[2]) {
+          entries = entries.filter((e) => e.Timestamp._ < Date.parse(m[2]));
+          return;
+        }
+        throw new Error(`Unsupported clause: ${clause}`);
       });
     }
     if (query._fields.length) {


### PR DESCRIPTION
This PR supports partitions, so concurrently running controller actions can share a task queue backed up by Azure Storage table, without interfering with each other's task.