### PR TITLE
fix(lock): releaseLease should check whether the lock was acquired

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1361,6 +1361,51 @@
         }
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.1.0.tgz",
+      "integrity": "sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -5384,6 +5429,12 @@
         }
       }
     },
+    "just-extend": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
+      "dev": true
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -5768,6 +5819,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.ismatch": {
@@ -6653,6 +6710,19 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node-emoji": {
       "version": "1.10.0",
@@ -10835,6 +10905,23 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -11835,6 +11922,44 @@
         "chalk": "^2.3.2",
         "figures": "^2.0.0",
         "pkg-conf": "^2.1.0"
+      }
+    },
+    "sinon": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.3.tgz",
+      "integrity": "sha512-IKo9MIM111+smz9JGwLmw5U1075n1YXeAq8YeSFlndCLhAL5KGn6bLgu7b/4AYHTV/LcEMcRm2wU2YiL55/6Pg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.2",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.1.0",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "slash": {
@@ -12949,6 +13074,12 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "proxyquire": "2.1.3",
-    "semantic-release": "17.1.1"
+    "semantic-release": "17.1.1",
+    "sinon": "^9.0.3"
   },
   "lint-staged": {
     "*.js": "eslint"

--- a/src/Lock.js
+++ b/src/Lock.js
@@ -63,6 +63,9 @@ class Lock {
    * If necessary, create an empty text blob that will be used to acquire a lease on.
    */
   async init() {
+    if (this._initialized) {
+      return;
+    }
     const result = await this._blobSvc.doesBlobExist(this._blob);
     if (!result.exists) {
       try {
@@ -75,6 +78,7 @@ class Lock {
         }
       }
     }
+    this._initialized = true;
   }
 
   /**
@@ -123,11 +127,16 @@ class Lock {
 
   /**
    * Releases a lock previously acquired.
+   *
+   * @returns true if lock was previously acquired, otherwise false
    */
   async release() {
     const lease = this._lease;
-    await this._blobSvc.releaseLease(this._blob, lease);
-    this._lease = null;
+    if (lease) {
+      await this._blobSvc.releaseLease(this._blob, lease);
+      this._lease = null;
+    }
+    return !!lease;
   }
 }
 

--- a/test/TaskQueue.test.js
+++ b/test/TaskQueue.test.js
@@ -47,7 +47,7 @@ describe('TaskQueue validation tests', () => {
     const queue = new TaskQueue(params, console);
     const uuid = await queue.insert({});
     const task = await queue.get(uuid);
-    assert.equal(task.PartitionKey, '');
+    assert.strictEqual(task.PartitionKey, '');
   });
 });
 
@@ -77,52 +77,52 @@ describe('TaskQueue operation tests', () => {
   it('Create task queue', async () => {
     const queue = new TaskQueue(withPartitionKey(params), console);
     const s = queue.toString();
-    assert.notEqual(s, null);
+    assert.notStrictEqual(s, null);
   });
 
   it('Insert object into task queue', async () => {
     const queue = new TaskQueue(withPartitionKey(params), console);
     const uuid = await queue.insert({ foo: 'bar', is: true, when: Date.now() });
     const task = await queue.get(uuid);
-    assert.equal(task.status, 'not started');
+    assert.strictEqual(task.status, 'not started');
   });
 
   it('Fetching non-existing task', async () => {
     const queue = new TaskQueue(withPartitionKey(params), console);
     const task = await queue.get('dummy');
-    assert.equal(task, null);
+    assert.strictEqual(task, null);
   });
 
   it('Check done tasks', async () => {
     const queue = new TaskQueue(withPartitionKey(params), console);
     const uuid = await queue.insert({ foo: 'bar' });
     let done = await queue.done();
-    assert.equal(done.length, 0);
+    assert.strictEqual(done.length, 0);
     await queue.update(uuid, { status: 'done' });
     done = await queue.done();
-    assert.equal(done.length, 1);
-    assert.equal(done[0].RowKey, uuid);
+    assert.strictEqual(done.length, 1);
+    assert.strictEqual(done[0].RowKey, uuid);
   });
 
   it('Check error task', async () => {
     const queue = new TaskQueue(withPartitionKey(params), console);
     const uuid = await queue.insert({ foo: 'bar' });
     let error = await queue.error();
-    assert.equal(error, null);
+    assert.strictEqual(error, undefined);
     await queue.update(uuid, { status: 'error', error: new Error() });
     error = await queue.error();
-    assert.equal(error.RowKey, uuid);
+    assert.strictEqual(error.RowKey, uuid);
   });
 
   it('Check dead task', async () => {
     const queue = new TaskQueue(withPartitionKey(params), console);
     const uuid = await queue.insert({ foo: 'bar' });
     let dead = await queue.dead(1000);
-    assert.equal(dead, null);
+    assert.strictEqual(dead, undefined);
     await sleep(10);
     dead = await queue.dead(9);
-    assert.notEqual(dead, null);
-    assert.equal(dead.RowKey, uuid);
+    assert.notStrictEqual(dead, null);
+    assert.strictEqual(dead.RowKey, uuid);
   });
 
   it('Check wrongly typed uuid is detected', async () => {
@@ -135,8 +135,8 @@ describe('TaskQueue operation tests', () => {
     await queue1.insert({});
     const queue2 = new TaskQueue(withPartitionKey(params), console);
     await queue2.insert({});
-    assert.equal(await queue1.tasks(), 1);
-    assert.equal(await queue2.size(), 2);
+    assert.strictEqual(await queue1.tasks(), 1);
+    assert.strictEqual(await queue2.size(), 2);
   });
 
   it('Task queue should return empty list when acquire fails', async () => {
@@ -148,6 +148,6 @@ describe('TaskQueue operation tests', () => {
     const uuid = await queue.insert({ foo: 'bar' });
     await queue.update(uuid, { status: 'done' });
     const done = await queue.done();
-    assert.equal(done.length, 0);
+    assert.strictEqual(done.length, 0);
   });
 });

--- a/test/blob/BlobService.js
+++ b/test/blob/BlobService.js
@@ -34,44 +34,42 @@ class BlobService {
   doesBlobExist(container, blob, opts, callback) {
     const cb = callback || opts;
 
-    const data = this._getOrCreateContainer(container);
-    cb(null, { exists: !!data[blob] });
+    const cont = this._getOrCreateContainer(container);
+    cb(null, { exists: !!cont[blob] });
   }
 
   createBlockBlobFromText(container, blob, text, opts, callback) {
     const cb = callback || opts;
 
-    const data = this._getOrCreateContainer(container);
-    if (data.error) {
-      cb(data.error);
-    }
-    data[blob] = { text, lease: null };
+    const cont = this._getOrCreateContainer(container);
+    cont[blob] = { text, lease: null };
     cb(null);
   }
 
   acquireLease(container, blob, opts, callback) {
     const cb = callback || opts;
 
-    const data = this._getOrCreateContainer(container);
-    const obj = data[blob];
-    if (obj.error) {
-      cb(obj.error);
+    const cont = this._getOrCreateContainer(container);
+    let obj = cont[blob];
+    if (!obj) {
+      cont[blob] = { text: '', lease: null };
+      obj = cont[blob];
     }
     if (obj.lease) {
       const e = new Error();
       e.code = 'LeaseAlreadyPresent';
       cb(e);
     }
-    const lease = Math.random().toString(16).substr(2);
-    obj.lease = lease;
-    cb(null, lease);
+    const id = Math.random().toString(16).substr(2);
+    obj.lease = id;
+    cb(null, { id });
   }
 
   releaseLease(container, blob, lease, opts, callback) {
     const cb = callback || opts;
 
-    const data = this._getOrCreateContainer(container);
-    const obj = data[blob];
+    const cont = this._getOrCreateContainer(container);
+    const obj = cont[blob];
     obj.lease = null;
 
     cb(null, lease);

--- a/test/change.test.js
+++ b/test/change.test.js
@@ -27,10 +27,10 @@ describe('Change class tests', () => {
         itemId: 'foo-bar',
       },
     });
-    assert.equal(change.path, '/foo');
-    assert.equal(change.uid, '1234');
-    assert.equal(change.type, 'added');
-    assert.equal(change.deleted, false);
+    assert.strictEqual(change.path, '/foo');
+    assert.strictEqual(change.uid, '1234');
+    assert.strictEqual(change.type, 'added');
+    assert.strictEqual(change.deleted, false);
     assert.deepEqual(change.provider, {
       itemId: 'foo-bar',
     });
@@ -40,10 +40,10 @@ describe('Change class tests', () => {
     const change = new Change({
       path: '/foo',
     });
-    assert.equal(change.path, '/foo');
-    assert.equal(change.uid, null);
-    assert.equal(change.type, 'modified');
-    assert.equal(change.deleted, false);
+    assert.strictEqual(change.path, '/foo');
+    assert.strictEqual(change.uid, null);
+    assert.strictEqual(change.type, 'modified');
+    assert.strictEqual(change.deleted, false);
   });
 
   it('Can create a new delete change instance', () => {
@@ -51,8 +51,8 @@ describe('Change class tests', () => {
       path: '/foo',
       type: 'deleted',
     });
-    assert.equal(change.path, '/foo');
-    assert.equal(change.deleted, true);
+    assert.strictEqual(change.path, '/foo');
+    assert.strictEqual(change.deleted, true);
   });
 
   it('Can create a change with no path', () => {
@@ -60,15 +60,15 @@ describe('Change class tests', () => {
       uid: '1234',
       type: 'deleted',
     });
-    assert.equal(change.path, undefined);
-    assert.equal(change.deleted, true);
-    assert.equal(change.uid, '1234');
+    assert.strictEqual(change.path, undefined);
+    assert.strictEqual(change.deleted, true);
+    assert.strictEqual(change.uid, '1234');
   });
 
   it('Can create a change instance from params', () => {
     const change = Change.fromParams({ path: '/foo' });
-    assert.equal(change.path, '/foo');
-    assert.equal(change.uid, null);
+    assert.strictEqual(change.path, '/foo');
+    assert.strictEqual(change.uid, null);
   });
 
   it('Can create a change instance from observation params', () => {
@@ -81,9 +81,9 @@ describe('Change class tests', () => {
         },
       },
     });
-    assert.equal(change.path, '/foo/bar');
-    assert.equal(change.uid, '1234');
-    assert.equal(change.deleted, true);
+    assert.strictEqual(change.path, '/foo/bar');
+    assert.strictEqual(change.uid, '1234');
+    assert.strictEqual(change.deleted, true);
   });
 
   it('Can create a change instance from observation params with mount point', () => {
@@ -100,9 +100,9 @@ describe('Change class tests', () => {
         },
       },
     });
-    assert.equal(change.path, '/en/bar');
-    assert.equal(change.uid, '1234');
-    assert.equal(change.deleted, true);
+    assert.strictEqual(change.path, '/en/bar');
+    assert.strictEqual(change.uid, '1234');
+    assert.strictEqual(change.deleted, true);
   });
 
   it('Can create a change instance from observation params with mount point at root', () => {
@@ -117,7 +117,7 @@ describe('Change class tests', () => {
         },
       },
     });
-    assert.equal(change.path, '/en/documents/bar');
+    assert.strictEqual(change.path, '/en/documents/bar');
   });
 
   it('Can create a change instance from observation params with mount path at root', () => {
@@ -132,7 +132,7 @@ describe('Change class tests', () => {
         },
       },
     });
-    assert.equal(change.path, '/bar');
+    assert.strictEqual(change.path, '/bar');
   });
 
   it('Can create a change instance from observation params with non matching mountpoint', () => {
@@ -147,6 +147,6 @@ describe('Change class tests', () => {
         },
       },
     });
-    assert.equal(change.path, '/documents/bar');
+    assert.strictEqual(change.path, '/documents/bar');
   });
 });


### PR DESCRIPTION
This is to remedy the following error that sometimes appeared in the log:
```
An unexpected error occurred { StorageError: An HTTP header that's mandatory for this request is not specified. }
```
The HTTP header mentioned is `x-ms-lease-id`, which can happen to be empty if the `acquireLock` already fails.